### PR TITLE
Add pytest workflow and refactor scraper for testability

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: Run tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+      - name: Run pytest
+        run: pytest

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ Automated scraper using Playwright for intelligent browsing of Victorian council
 1. `pip install -r requirements.txt && playwright install`
 2. Edit `config.py` (e.g., TEST_MODE=False for full run).
 3. `python scraper.py` → Generates `jobs_output.json` + `rss.xml`.
+4. `pytest` → Runs unit tests for helper utilities and RSS generation.
+
+CI runs the same pytest suite automatically via `.github/workflows/tests.yml` for every push/PR, ensuring utility code stays healthy.
 
 ## GitHub Automation
 - Actions: Daily scrape → Commits JSON/RSS.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 playwright==1.47.0
 pandas==2.2.2
 python-dateutil==2.9.0
+pytest==8.3.2

--- a/scraper.py
+++ b/scraper.py
@@ -5,16 +5,16 @@ import uuid
 import logging
 from datetime import datetime, timedelta
 from dateutil import parser as date_parser
-from urllib.parse import urljoin
 from xml.etree import ElementTree as ET
 from xml.dom import minidom
 from playwright.sync_api import sync_playwright
-import pandas as pd
-import os
 
 # Setup logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s',
-                    handlers=[logging.FileHandler('scrape.log'), logging.StreamHandler()])
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s',
+    handlers=[logging.FileHandler('scrape.log'), logging.StreamHandler()]
+)
 logger = logging.getLogger(__name__)
 
 # Hardcoded for Ballarat Pulse
@@ -23,97 +23,80 @@ COUNCIL_NAME = "City of Ballarat"
 MAX_JOBS = 20  # Buffer for 15+
 DELAY_SCROLL = 1  # Seconds
 
-all_new_jobs = []
 
 def parse_date(text, field_type='closing'):
     """Robust date parsing."""
     if not text or text == "N/A":
         return "N/A"
-    date_match = re.search(r'(\d{1,2}[a-z]?\s+(?:January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{4})', text, re.I)
+
+    date_match = re.search(
+        r'(\d{1,2}[a-z]?\s+(?:January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{4})',
+        text,
+        re.I,
+    )
     if date_match:
         clean_text = date_match.group(1)
     elif "ongoing" in text.lower():
         return "N/A"
     else:
         clean_text = text
+
     try:
         parsed = date_parser.parse(clean_text)
         return parsed.isoformat()
-    except:
+    except Exception:  # pragma: no cover - log only
         logger.warning(f"Failed to parse {field_type} date: {text}")
         return "N/A"
+
 
 def slug_title(title):
     """Slug for URL from title."""
     return re.sub(r'[^a-zA-Z0-9\s-]', '', title).lower().strip().replace(' ', '-').replace('--', '-')
 
-def generate_rss(jobs):
+
+def generate_rss(jobs, now=None):
     """Generate RSS XML from jobs (recent only)."""
-    recent_jobs = [j for j in jobs if j['posted_date'] != "N/A" and 
-                   datetime.fromisoformat(j['posted_date'].replace('Z', '+00:00')) > 
-                   datetime.now() - timedelta(days=30)]
-    
+    now = now or datetime.now()
+    cutoff = now - timedelta(days=30)
+
+    recent_jobs = []
+    for job in jobs:
+        posted = job.get('posted_date', "N/A")
+        if posted == "N/A":
+            continue
+        try:
+            posted_dt = datetime.fromisoformat(posted.replace('Z', '+00:00'))
+        except ValueError:
+            logger.warning(f"Invalid posted_date format for RSS: {posted}")
+            continue
+        if posted_dt > cutoff:
+            recent_jobs.append(job)
+
     rss = ET.Element('rss', version='2.0')
     channel = ET.SubElement(rss, 'channel')
     ET.SubElement(channel, 'title').text = 'Victorian Councils Job Feed'
     ET.SubElement(channel, 'link').text = 'https://bandsight.github.io/vic/'
     ET.SubElement(channel, 'description').text = 'Latest jobs from Victorian councils.'
-    ET.SubElement(channel, 'pubDate').text = datetime.now().strftime('%a, %d %b %Y %H:%M:%S %z')
-    
+    ET.SubElement(channel, 'pubDate').text = now.strftime('%a, %d %b %Y %H:%M:%S %z')
+
     for job in recent_jobs:
         item = ET.SubElement(channel, 'item')
         ET.SubElement(item, 'title').text = f"{job['council']} - {job['title']}"
         ET.SubElement(item, 'link').text = job['detail_url']
         ET.SubElement(item, 'description').text = job['description'][:200] + '...'
-        ET.SubElement(item, 'pubDate').text = job['posted_date'] if job['posted_date'] != "N/A" else job['scraped_at']
+        ET.SubElement(item, 'pubDate').text = (
+            job['posted_date'] if job['posted_date'] != "N/A" else job['scraped_at']
+        )
         ET.SubElement(item, 'category').text = job['council']
         ET.SubElement(item, 'guid').text = job['reference_number']
-    
+
     rough_string = ET.tostring(rss, 'unicode')
     reparsed = minidom.parseString(rough_string)
     return reparsed.toprettyxml(indent='  ')
 
-# Main scrape for Pulse
-with sync_playwright() as p:
-    browser = p.chromium.launch(headless=True)
-    context = browser.new_context(
-        user_agent='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
-    )
-    page = context.new_page()
 
-    logger.info(f"Starting scrape for {COUNCIL_NAME} at {PULSE_URL}")
-
-    page.goto(PULSE_URL, timeout=90000)
-    page.wait_for_load_state('domcontentloaded', timeout=30000)
-    page_title = page.title()
-    logger.info(f"Page title: {page_title}")
-
-    # Trigger Vue load if defined
-    try:
-        page.evaluate("if (typeof load === 'function') load();")
-        logger.info("Triggered Vue load().")
-    except:
-        logger.warning("No load() function found.")
-
-    # Wait for Vue to mount and render jobs (check for .row.card-row from template)
-    try:
-        page.wait_for_function("document.querySelectorAll('.row.card-row').length >= 15", timeout=60000)
-        logger.info("15+ job rows loaded via Vue.")
-    except:
-        logger.warning("Less than 15 job rows after 60s—continuing with available.")
-
-    # Screenshot for debug
-    page.screenshot(path='pulse_list.png')
-    logger.info("Screenshot saved: pulse_list.png")
-
-    # Extra scrolls to ensure full load
-    for i in range(20):
-        page.evaluate("window.scrollTo(0, document.body.scrollHeight)")
-        time.sleep(DELAY_SCROLL)
-        logger.info(f"Scroll {i+1}/20 complete.")
-
-    # Access Vue data directly via evaluate (wrapped in IIFE for scope)
-    vue_jobs = []
+def _extract_jobs_from_vue(page):
+    """Attempt to pull jobs directly from the Vue instance."""
     try:
         vue_jobs = page.evaluate("""
             (function() {
@@ -139,123 +122,187 @@ with sync_playwright() as p:
             })();
         """)
         logger.info(f"Accessed Vue data: {len(vue_jobs)} jobs.")
+        return vue_jobs
     except Exception as e:
         logger.error(f"Error accessing Vue data: {e}")
+        return []
 
-    # Fallback: Scrape from rendered DOM if Vue failed (simplified pure JS)
-    if len(vue_jobs) == 0:
-        try:
-            dom_jobs = page.evaluate("""
-                (function() {
-                    try {
-                        var rows = document.querySelectorAll('.row.card-row');
-                        var jobs = [];
-                        for (var i = 0; i < rows.length; i++) {
-                            var row = rows[i];
-                            var title = row.querySelector('.job-title span') ? row.querySelector('.job-title span').textContent.trim() : 'N/A';
-                            if (title === 'N/A') continue;
-                            var linkId = 'unknown';  # Derive from pattern or skip
-                            var rowText = row.innerText;
-                            // Regex for fields from row text (fixed backslashes)
-                            var closingMatch = rowText.match(/Closing date:\\s*([\\w\\s,]+\\d{4})/i);
-                            var compensationMatch = rowText.match(/Compensation:\\s*([\\$\\d,\\s-]+)/i);
-                            var locationMatch = rowText.match(/Location:\\s*([\\w\\s,]+)/i);
-                            var departmentMatch = rowText.match(/Department:\\s*([\\w\\s]+)/i);
-                            var employmentMatch = rowText.match(/Employment type:\\s*([\\w\\s]+)/i);
-                            jobs.push({
-                                title: title,
-                                linkId: linkId,
-                                closingDate: closingMatch ? closingMatch[1].trim() : 'N/A',
-                                compensation: compensationMatch ? compensationMatch[1].trim() : 'N/A',
-                                location: locationMatch ? locationMatch[1].trim() : 'N/A',
-                                department: departmentMatch ? departmentMatch[1].trim() : 'N/A',
-                                employmentType: employmentMatch ? employmentMatch[1].trim() : 'N/A',
-                                jobRef: linkId  # Derive from linkId for fallback
-                            });
-                        }
-                        return jobs;
-                    } catch (e) {
-                        console.error('DOM fallback error:', e);
+
+def _extract_jobs_from_dom(page):
+    """Fallback scraping directly from the rendered DOM."""
+    try:
+        dom_jobs = page.evaluate("""
+            (function() {
+                try {
+                    var rows = document.querySelectorAll('.row.card-row');
+                    var jobs = [];
+                    for (var i = 0; i < rows.length; i++) {
+                        var row = rows[i];
+                        var titleNode = row.querySelector('.job-title span');
+                        var title = titleNode ? titleNode.textContent.trim() : 'N/A';
+                        if (title === 'N/A') continue;
+                        var linkId = 'unknown'; // Derive from pattern or skip
+                        var rowText = row.innerText;
+                        // Regex for fields from row text (fixed backslashes)
+                        var closingMatch = rowText.match(/Closing date:\\s*([\\w\\s,]+\\d{4})/i);
+                        var compensationMatch = rowText.match(/Compensation:\\s*([\\$\\d,\\s-]+)/i);
+                        var locationMatch = rowText.match(/Location:\\s*([\\w\\s,]+)/i);
+                        var departmentMatch = rowText.match(/Department:\\s*([\\w\\s]+)/i);
+                        var employmentMatch = rowText.match(/Employment type:\\s*([\\w\\s]+)/i);
+                        jobs.push({
+                            title: title,
+                            linkId: linkId,
+                            closingDate: closingMatch ? closingMatch[1].trim() : 'N/A',
+                            compensation: compensationMatch ? compensationMatch[1].trim() : 'N/A',
+                            location: locationMatch ? locationMatch[1].trim() : 'N/A',
+                            department: departmentMatch ? departmentMatch[1].trim() : 'N/A',
+                            employmentType: employmentMatch ? employmentMatch[1].trim() : 'N/A',
+                            jobRef: linkId // Derive from linkId for fallback
+                        });
                     }
-                    return [];
-                })();
-            """)
-            logger.info(f"Fallback DOM scrape: {len(dom_jobs)} jobs.")
-            vue_jobs = dom_jobs  # Use fallback
-        except Exception as fallback_e:
-            logger.error(f"Fallback DOM error: {fallback_e}")
+                    return jobs;
+                } catch (e) {
+                    console.error('DOM fallback error:', e);
+                }
+                return [];
+            })();
+        """)
+        logger.info(f"Fallback DOM scrape: {len(dom_jobs)} jobs.")
+        return dom_jobs
+    except Exception as fallback_e:
+        logger.error(f"Fallback DOM error: {fallback_e}")
+        return []
 
-    # Process jobs (from Vue or fallback)
-    for job in vue_jobs[:MAX_JOBS]:
-        job_title = job['title'] or "N/A"
-        link_id = job['linkId'] or 'unknown'
-        job_ref = job.get('jobRef', link_id) or str(uuid.uuid4())  # Safe get
-        # Construct detail URL
-        slug = slug_title(job_title)
-        full_url = f"{PULSE_URL}/job/{link_id}/{slug}?source=public"
-        
-        # Extract from job dict
-        closing_text = job.get('closingDate', "N/A") or "N/A"
-        closing_date = parse_date(closing_text, 'closing')
-        salary = job.get('compensation', "N/A") or "N/A"
-        location = job.get('location', "N/A") or "N/A"
-        employment_type = job.get('employmentType', "N/A") or "N/A"
-        department = job.get('department', "N/A") or "N/A"
-        posted_date = "N/A"  # Assume scraped_at
 
-        # Goto detail for full description/requirements
-        detail_page = context.new_page()
+def scrape_pulse_jobs(max_jobs=MAX_JOBS, headless=True):
+    """Scrape the Ballarat Pulse site and return a list of job dictionaries."""
+    all_new_jobs = []
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=headless)
+        context = browser.new_context(
+            user_agent='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+        )
+        page = context.new_page()
+
+        logger.info(f"Starting scrape for {COUNCIL_NAME} at {PULSE_URL}")
+
+        page.goto(PULSE_URL, timeout=90000)
+        page.wait_for_load_state('domcontentloaded', timeout=30000)
+        page_title = page.title()
+        logger.info(f"Page title: {page_title}")
+
+        # Trigger Vue load if defined
         try:
-            detail_page.goto(full_url, timeout=60000)
-            detail_page.wait_for_load_state('domcontentloaded', timeout=30000)
-            description = detail_page.locator('.job-description, .role-overview, text=/duties|overview/i').first.inner_text()[:500] or "N/A"
-            requirements = [req.strip() for req in detail_page.locator('ul:has-text("requirements"), li:has-text("qualification")').all_inner_texts() if req.strip()] or []
-            application_instructions = detail_page.locator('text=/apply|submit/i').first.inner_text().strip() or "N/A"
-            contact_info = detail_page.locator('a[href^="mailto"]').first.inner_text().strip() or "N/A"
-            band_level = detail_page.locator('text=/VPS|band|level|EO|ST|grade/i').first.inner_text().strip() or "N/A"
-        except Exception as detail_e:
-            logger.error(f"Detail page error for {full_url}: {detail_e}")
-            description = "N/A"
-            requirements = []
-            application_instructions = "N/A"
-            contact_info = "N/A"
-            band_level = "N/A"
-        finally:
-            detail_page.close()
+            page.evaluate("if (typeof load === 'function') load();")
+            logger.info("Triggered Vue load().")
+        except Exception:
+            logger.warning("No load() function found.")
 
-        all_new_jobs.append({
-            'title': job_title,
-            'council': COUNCIL_NAME,
-            'detail_url': full_url,
-            'closing_date': closing_date,
-            'location': location,
-            'employment_type': employment_type,
-            'salary': salary,
-            'band_level': band_level,
-            'description': description,
-            'requirements': requirements,
-            'application_instructions': application_instructions,
-            'contact_info': contact_info,
-            'reference_number': job_ref,
-            'department': department,
-            'posted_date': posted_date,
-            'scraped_at': datetime.now().isoformat()
-        })
-        logger.info(f"Added job: {job_title} for {COUNCIL_NAME} (Ref: {job_ref})")
-        time.sleep(1)
+        # Wait for Vue to mount and render jobs (check for .row.card-row from template)
+        try:
+            page.wait_for_function("document.querySelectorAll('.row.card-row').length >= 15", timeout=60000)
+            logger.info("15+ job rows loaded via Vue.")
+        except Exception:
+            logger.warning("Less than 15 job rows after 60s—continuing with available.")
 
-    browser.close()
+        # Screenshot for debug
+        page.screenshot(path='pulse_list.png')
+        logger.info("Screenshot saved: pulse_list.png")
 
-# Full Overwrite JSON (no append/dedup for testing)
-output_file = 'jobs_output.json'
-with open(output_file, 'w', encoding='utf-8') as f:
-    json.dump(all_new_jobs, f, indent=2, default=str)
+        # Extra scrolls to ensure full load
+        for i in range(20):
+            page.evaluate("window.scrollTo(0, document.body.scrollHeight)")
+            time.sleep(DELAY_SCROLL)
+            logger.info(f"Scroll {i+1}/20 complete.")
 
-logger.info(f"Overwrote JSON with {len(all_new_jobs)} jobs from Pulse.")
+        vue_jobs = _extract_jobs_from_vue(page)
+        if not vue_jobs:
+            vue_jobs = _extract_jobs_from_dom(page)
 
-# Generate RSS
-rss_xml = generate_rss(all_new_jobs)
-with open('rss.xml', 'w', encoding='utf-8') as f:
-    f.write(rss_xml)
+        for job in vue_jobs[:max_jobs]:
+            job_title = job.get('title') or "N/A"
+            link_id = job.get('linkId') or 'unknown'
+            job_ref = job.get('jobRef', link_id) or str(uuid.uuid4())  # Safe get
+            slug = slug_title(job_title)
+            full_url = f"{PULSE_URL}/job/{link_id}/{slug}?source=public"
 
-logger.info(f"RSS generated with {len(all_new_jobs)} jobs.")
+            closing_text = job.get('closingDate', "N/A") or "N/A"
+            closing_date = parse_date(closing_text, 'closing')
+            salary = job.get('compensation', "N/A") or "N/A"
+            location = job.get('location', "N/A") or "N/A"
+            employment_type = job.get('employmentType', "N/A") or "N/A"
+            department = job.get('department', "N/A") or "N/A"
+            posted_date = "N/A"  # Assume scraped_at
+
+            detail_page = context.new_page()
+            try:
+                detail_page.goto(full_url, timeout=60000)
+                detail_page.wait_for_load_state('domcontentloaded', timeout=30000)
+                description = detail_page.locator('.job-description, .role-overview, text=/duties|overview/i').first.inner_text()[:500] or "N/A"
+                requirements = [
+                    req.strip()
+                    for req in detail_page.locator('ul:has-text("requirements"), li:has-text("qualification")').all_inner_texts()
+                    if req.strip()
+                ] or []
+                application_instructions = detail_page.locator('text=/apply|submit/i').first.inner_text().strip() or "N/A"
+                contact_info = detail_page.locator('a[href^="mailto"]').first.inner_text().strip() or "N/A"
+                band_level = detail_page.locator('text=/VPS|band|level|EO|ST|grade/i').first.inner_text().strip() or "N/A"
+            except Exception as detail_e:
+                logger.error(f"Detail page error for {full_url}: {detail_e}")
+                description = "N/A"
+                requirements = []
+                application_instructions = "N/A"
+                contact_info = "N/A"
+                band_level = "N/A"
+            finally:
+                detail_page.close()
+
+            all_new_jobs.append({
+                'title': job_title,
+                'council': COUNCIL_NAME,
+                'detail_url': full_url,
+                'closing_date': closing_date,
+                'location': location,
+                'employment_type': employment_type,
+                'salary': salary,
+                'band_level': band_level,
+                'description': description,
+                'requirements': requirements,
+                'application_instructions': application_instructions,
+                'contact_info': contact_info,
+                'reference_number': job_ref,
+                'department': department,
+                'posted_date': posted_date,
+                'scraped_at': datetime.now().isoformat()
+            })
+            logger.info(f"Added job: {job_title} for {COUNCIL_NAME} (Ref: {job_ref})")
+            time.sleep(1)
+
+        context.close()
+        browser.close()
+
+    logger.info(f"Scraped {len(all_new_jobs)} jobs from {COUNCIL_NAME}.")
+    return all_new_jobs
+
+
+def save_jobs_to_json(jobs, output_file='jobs_output.json'):
+    with open(output_file, 'w', encoding='utf-8') as f:
+        json.dump(jobs, f, indent=2, default=str)
+    logger.info(f"Saved {len(jobs)} jobs to {output_file}.")
+
+
+def save_rss_feed(jobs, output_file='rss.xml', now=None):
+    rss_xml = generate_rss(jobs, now=now)
+    with open(output_file, 'w', encoding='utf-8') as f:
+        f.write(rss_xml)
+    logger.info(f"RSS generated with {len(jobs)} jobs written to {output_file}.")
+
+
+def main():
+    jobs = scrape_pulse_jobs()
+    save_jobs_to_json(jobs)
+    save_rss_feed(jobs)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,54 @@
+from datetime import datetime, timedelta
+import sys
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from scraper import parse_date, slug_title, generate_rss
+
+
+def test_parse_date_extracts_isoformat():
+    assert parse_date("Closing date: 5 September 2024") == "2024-09-05T00:00:00"
+
+
+def test_parse_date_returns_na_for_ongoing():
+    assert parse_date("Ongoing position", field_type='closing') == "N/A"
+
+
+def test_slug_title_strips_special_characters():
+    assert slug_title("Senior Planner (FT)") == "senior-planner-ft"
+
+
+def test_generate_rss_filters_recent_jobs():
+    now = datetime(2024, 1, 31, 12, 0, 0)
+    recent_posted = (now - timedelta(days=10)).isoformat()
+    old_posted = (now - timedelta(days=40)).isoformat()
+
+    jobs = [
+        {
+            'title': 'Recent Role',
+            'council': 'City of Ballarat',
+            'detail_url': 'https://example.com/recent',
+            'description': 'Great role',
+            'posted_date': recent_posted,
+            'scraped_at': now.isoformat(),
+            'reference_number': 'recent-ref'
+        },
+        {
+            'title': 'Old Role',
+            'council': 'City of Ballarat',
+            'detail_url': 'https://example.com/old',
+            'description': 'Old role',
+            'posted_date': old_posted,
+            'scraped_at': now.isoformat(),
+            'reference_number': 'old-ref'
+        }
+    ]
+
+    rss_xml = generate_rss(jobs, now=now)
+    rss = ET.fromstring(rss_xml)
+    items = rss.findall('./channel/item')
+
+    assert len(items) == 1
+    assert items[0].find('title').text == 'City of Ballarat - Recent Role'


### PR DESCRIPTION
## Summary
- refactor `scraper.py` so the Playwright logic lives behind functions, keeping helper utilities importable and adding a configurable RSS generator
- add a pytest suite that covers date parsing, slug creation, and RSS filtering behaviour
- document and automate the test run with a dedicated GitHub Actions workflow and dependency update

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691563f319d88324ab06530e6e2e509c)