### PR TITLE
Align repo defaults with Ballarat tenancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ Victorian councils directory again.
 3. Review `jobs_output.json`, `rss.xml`, `scrape.log`, and the latest
    `pulse_list.png` screenshot for troubleshooting.
 
+## Configuration
+The scraper now reads its tenancy metadata from `config.py`. The
+`ACTIVE_TENANCY` constant identifies the single Pulse tenancy (currently the
+City of Ballarat) along with expectations for how many job cards should load.
+Adjusting the dataclass or swapping in a different tenancy makes it clear when
+we intentionally expand beyond Ballarat again, and keeps the Playwright script
+in sync with those choices.
+
 ## Why Playwright (research summary)
 Pulse renders its public job listings fully client-side via Vue and only exposes
 minimal markup until the Vue instance finishes hydrating. Static HTTP requests

--- a/config.py
+++ b/config.py
@@ -1,8 +1,26 @@
-# Configuration for scraper
-TEST_MODE = True  # Set False for full 79 councils
-MAX_JOBS_PER_COUNCIL = 10  # Limit per site
-DELAY_BETWEEN_COUNCILS = 3  # Seconds
-DELAY_AFTER_CLICK = 3  # Seconds for loads
-RSS_DAYS_BACK = 30  # Jobs in RSS (filter by posted_date)
-FALLBACK_COUNCILS_FILE = 'fallback_councils.json'  # Backup if directory fails
-QUICK_TEST_COUNCILS = ['City of Ballarat']  # Run only these for debug (overrides TEST_MODE)
+"""Configuration for the Pulse job scraper."""
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PulseTenancy:
+    """Represents a single Pulse tenancy we can scrape."""
+    name: str
+    listing_url: str
+    min_card_rows: int = 15
+
+
+BALLARAT_TENANCY = PulseTenancy(
+    name="City of Ballarat",
+    listing_url="https://ballarat.pulsesoftware.com/Pulse/jobs",
+    min_card_rows=15,
+)
+
+# The tenancy we currently target. This keeps the scraper flexible when we
+# re-introduce multiple councils.
+ACTIVE_TENANCY = BALLARAT_TENANCY
+
+# Scraper tuning knobs
+MAX_JOBS = 20
+SCROLL_DELAY_SECONDS = 1
+RSS_LOOKBACK_DAYS = 30

--- a/fallback_councils.json
+++ b/fallback_councils.json
@@ -1,1 +1,6 @@
-[{"name": "City of Melbourne", "job_url": "https://www.melbourne.vic.gov.au/jobs-and-careers"}]
+[
+  {
+    "name": "City of Ballarat",
+    "job_url": "https://ballarat.pulsesoftware.com/Pulse/jobs"
+  }
+]

--- a/index.html
+++ b/index.html
@@ -1,12 +1,15 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Victorian Councils Jobs</title>
+    <title>City of Ballarat Pulse Jobs</title>
     <link rel="alternate" type="application/rss+xml" title="Jobs RSS" href="rss.xml">
 </head>
 <body>
-    <h1>Victorian Councils Job Data</h1>
-    <p><a href="jobs_output.json">Download JSON</a> | <a href="rss.xml">RSS Feed</a></p>
-    <p>Last updated: Auto via GitHub Actions.</p>
+    <h1>City of Ballarat Pulse Job Data</h1>
+    <p>
+        <a href="jobs_output.json">Download JSON</a> |
+        <a href="rss.xml">RSS Feed</a>
+    </p>
+    <p>Last updated when the Ballarat-only scraper runs.</p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- centralize the active Pulse tenancy and scraper knobs in `config.py` and wire the scraper to read from those settings
- refresh the site chrome, README, and fallback metadata so they clearly describe the Ballarat-only focus

## Testing
- `python -m compileall scraper.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69156da24b988324a1516d9d97855237)