### PR TITLE
Allow scrape workflow to push results

### DIFF
--- a/.github/workflows/scrape-jobs.yml
+++ b/.github/workflows/scrape-jobs.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 3 * * *'  # Daily 3 AM UTC
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   scrape:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- grant the scheduled scrape workflow write access to repository contents so that its git commits succeed

## Testing
- python -m compileall scraper.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915759e7e8c8324a44a1bc3197385e2)